### PR TITLE
Fixing the COVID-19 tag, putting it at the top of diseases list

### DIFF
--- a/src/components/diseases.css
+++ b/src/components/diseases.css
@@ -40,4 +40,10 @@
     position: absolute;
     z-index: 10000000;
   }
+
+  & .diseases__featured {
+    border: 1px solid var(--ruling-color);
+
+  }
 }
+

--- a/src/components/diseases.js
+++ b/src/components/diseases.js
@@ -16,6 +16,12 @@ export default function Diseases({ onSubmit, blacklist = [] }) {
   const [term, setTerm] = useState('');
   const [selected, setSelected] = useState(null);
 
+  const featured = useMemo(() => {
+    return DISEASES.filter(
+      subject => subject.featured
+    )
+  })
+
   const options = useMemo(() => {
     return DISEASES.filter(
       subject =>
@@ -65,6 +71,9 @@ export default function Diseases({ onSubmit, blacklist = [] }) {
           className="diseases__combobox-popover"
         >
           <ComboboxList persistSelection={true}>
+            {featured.map(subject => (
+              <ComboboxOption className="diseases__featured" key={subject.name} value={format(subject)} />
+            ))}
             {sorted.map(subject => (
               <ComboboxOption key={subject.name} value={format(subject)} />
             ))}

--- a/src/components/diseases.js
+++ b/src/components/diseases.js
@@ -16,12 +16,6 @@ export default function Diseases({ onSubmit, blacklist = [] }) {
   const [term, setTerm] = useState('');
   const [selected, setSelected] = useState(null);
 
-  const featured = useMemo(() => {
-    return DISEASES.filter(
-      subject => subject.featured
-    )
-  })
-
   const options = useMemo(() => {
     return DISEASES.filter(
       subject =>
@@ -71,11 +65,8 @@ export default function Diseases({ onSubmit, blacklist = [] }) {
           className="diseases__combobox-popover"
         >
           <ComboboxList persistSelection={true}>
-            {featured.map(subject => (
-              <ComboboxOption className="diseases__featured" key={subject.name} value={format(subject)} />
-            ))}
             {sorted.map(subject => (
-              <ComboboxOption key={subject.name} value={format(subject)} />
+              <ComboboxOption className={subject.featured ? "diseases__featured" : ""} key={subject.name} value={format(subject)} />
             ))}
           </ComboboxList>
         </ComboboxPopover>

--- a/src/components/facets.css
+++ b/src/components/facets.css
@@ -39,6 +39,11 @@
     & input {
       width: 2em;
     }
+
+    &-featured {
+      color: var(--prereview-red);
+      font-weight: bold;
+    }
   }
 }
 

--- a/src/components/facets.js
+++ b/src/components/facets.js
@@ -176,7 +176,7 @@ export default function Facets({ counts = {}, ranges = {}, isFetching }) {
                   isFetching || !(counts.subjectName || {})[subject.name]
                 }
                 label={
-                  <span className="facets__facet-label">
+                  <span className={`facets__facet-label ${subject.featured ? "facets__facet-label-featured" : ""}`}>
                     {subject.alternateName ? (
                       <abbr title={subject.name}>{subject.alternateName}</abbr>
                     ) : (

--- a/src/constants.js
+++ b/src/constants.js
@@ -138,7 +138,7 @@ export const INDEXED_PREPRINT_PROPS = [
 // See https://github.com/PREreview/rapid-prereview/issues/10
 export const DISEASES = [
   {
-    name: '2019 novel coronavirus',
+    name: 'Coronavirus disease 2019',
     alternateName: 'COVID-19',
     priority: 'red',
     featured: true

--- a/src/constants.js
+++ b/src/constants.js
@@ -204,7 +204,8 @@ export const DISEASES = [
   {
     name: '2019 novel coronavirus',
     alternateName: 'COVID-19',
-    priority: 'red'
+    priority: 'red', 
+    featured: true
   },
 
   {

--- a/src/constants.js
+++ b/src/constants.js
@@ -203,7 +203,7 @@ export const DISEASES = [
 
   {
     name: '2019 novel coronavirus',
-    alternateName: '2019-nCoV',
+    alternateName: 'COVID-19',
     priority: 'red'
   },
 

--- a/src/constants.js
+++ b/src/constants.js
@@ -138,6 +138,12 @@ export const INDEXED_PREPRINT_PROPS = [
 // See https://github.com/PREreview/rapid-prereview/issues/10
 export const DISEASES = [
   {
+    name: '2019 novel coronavirus',
+    alternateName: 'COVID-19',
+    priority: 'red',
+    featured: true
+  },
+  {
     name: 'Chikungunya',
     priority: 'orange'
   },
@@ -199,13 +205,6 @@ export const DISEASES = [
   {
     name: 'Nipah',
     priority: 'red'
-  },
-
-  {
-    name: '2019 novel coronavirus',
-    alternateName: 'COVID-19',
-    priority: 'red', 
-    featured: true
   },
 
   {


### PR DESCRIPTION
Fixes #96.

This is a product of pairing with @rudietuesdays!

For now, we hard coded COVID-19 into the top of the DISEASES constant that populates the disease subject tag list. We added some styling to highlight it. 

For a future feature, we would want to add a "featured" flag or something to diseases so that putting them at the top of the list can be done programatically. 

<img width="378" alt="Screen Shot 2020-05-15 at 16 28 33" src="https://user-images.githubusercontent.com/13320420/82093492-3cbf8a00-96c9-11ea-81ce-8c3389553f72.png">

<img width="602" alt="Screen Shot 2020-05-15 at 16 29 02" src="https://user-images.githubusercontent.com/13320420/82093510-42b56b00-96c9-11ea-8bd4-d1e73914b04f.png">

