### PR TITLE
Keep diseases selected after clicking on "Next Page"

### DIFF
--- a/src/components/home.js
+++ b/src/components/home.js
@@ -293,8 +293,8 @@ export default function Home() {
               <Button
                 onClick={() => {
                   history.push({
-                    pathname: location.pathame,
-                    search: createPreprintQs({}, location.search)
+                    pathname: location.pathname,
+                    search: createPreprintQs({ text: params.get('q') }, location.search)
                   });
                 }}
               >
@@ -310,8 +310,8 @@ export default function Home() {
                 className="home__next-page-button"
                 onClick={() => {
                   history.push({
-                    pathname: location.pathame,
-                    search: createPreprintQs({}, location.search),
+                    pathname: location.pathname,
+                    search: createPreprintQs({ text: params.get('q') }, location.search),
                     state: { bookmark: results.bookmark }
                   });
                 }}


### PR DESCRIPTION
Fixes #133.


<!-- Issuehunt content -->

---

<details>
<summary>
<b>IssueHunt Summary</b>
</summary>

### Referenced issues

This pull request has been submitted to:
- [#133: COVID-19 search gets unselected after clicking on "Next Page" in the list of preprints](https://issuehunt.io/repos/208844948/issues/133)
---
</details>
<!-- /Issuehunt content-->