### PR TITLE
fix: User Settings header adjustment

### DIFF
--- a/src/components/admin-panel.js
+++ b/src/components/admin-panel.js
@@ -39,7 +39,7 @@ export default function AdminPanel() {
       <Helmet>
         <title>{ORG} • Admin panel</title>
       </Helmet>
-      <HeaderBar />
+      <HeaderBar closeGap />
 
       <section>
         <header className="admin-panel__header">

--- a/src/components/block-panel.js
+++ b/src/components/block-panel.js
@@ -39,7 +39,7 @@ export default function BlockPanel() {
       <Helmet>
         <title>{ORG} • Moderate Users</title>
       </Helmet>
-      <HeaderBar />
+      <HeaderBar closeGap />
 
       <section>
         <header className="block-panel__header">

--- a/src/components/header-bar.js
+++ b/src/components/header-bar.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState, useEffect } from 'react';
 import PropTypes from 'prop-types';
 import { MdMenu } from 'react-icons/md';
 import { Link } from 'react-router-dom';
@@ -13,12 +13,44 @@ import NoticeBadge from './notice-badge';
 import { checkIfRoleLacksMininmalData } from '../utils/roles';
 import { useIsMobile } from '../hooks/ui-hooks';
 
-export default function HeaderBar({ onClickMenuButton }) {
+export default function HeaderBar({ onClickMenuButton, closeGap }) {
   const [user] = useUser();
   const [role] = useRole(user && user.defaultRole);
 
   const showProfileNotice = checkIfRoleLacksMininmalData(role);
   const isMobile = useIsMobile();
+
+  const [initialHeaderOffset, setinitialHeaderOffset] = useState(null);
+  const [initialHeaderOffsetMobile, setinitialHeaderOffsetMobile] = useState(
+    null
+  );
+
+  useEffect(() => {
+    setHeaderOffset();
+  }, []);
+
+  const setHeaderOffset = () => {
+    const headerBarOffset = window
+      .getComputedStyle(document.documentElement)
+      .getPropertyValue('--announcement-bar-height');
+
+    const headerBarOffsetMobile = window
+      .getComputedStyle(document.documentElement)
+      .getPropertyValue('--announcement-bar-height--mobile');
+
+    setinitialHeaderOffset(headerBarOffset);
+    setinitialHeaderOffsetMobile(headerBarOffsetMobile);
+  };
+
+  document.documentElement.style.setProperty(
+    '--announcement-bar-height',
+    closeGap ? '0px' : initialHeaderOffset
+  );
+
+  document.documentElement.style.setProperty(
+    '--announcement-bar-height--mobile',
+    closeGap ? '0px' : initialHeaderOffsetMobile
+  );
 
   return (
     <div className="header-bar">
@@ -160,4 +192,5 @@ export default function HeaderBar({ onClickMenuButton }) {
 
 HeaderBar.propTypes = {
   onClickMenuButton: PropTypes.func,
+  closeGap: PropTypes.bool
 };

--- a/src/components/moderate.js
+++ b/src/components/moderate.js
@@ -85,7 +85,7 @@ export default function Moderate() {
       <Helmet>
         <title>{ORG} • Moderate Reviews</title>
       </Helmet>
-      <HeaderBar />
+      <HeaderBar closeGap />
 
       <section>
         <header className="moderate__header">

--- a/src/components/profile.js
+++ b/src/components/profile.js
@@ -35,7 +35,7 @@ export default function Profile() {
 
   return (
     <div className="profile">
-      <HeaderBar />
+      <HeaderBar closeGap />
 
       <Helmet>
         <title>

--- a/src/components/settings.js
+++ b/src/components/settings.js
@@ -20,7 +20,7 @@ export default function Settings() {
         <title>{ORG} • Settings</title>
       </Helmet>
 
-      <HeaderBar />
+      <HeaderBar closeGap />
       <div className="settings__content">
         <section className="settings__section">
           <h2 className="settings__title">User Settings</h2>


### PR DESCRIPTION
Closes #131.

It was a bit tricky to get into the project but I think I found a clean solution.

I would recommend to change the `useIsMobile()` hook to be responsible for mobile only. 

It confused me that it has `max-width: 900px` set, because the `--mobile` css variable is only taking care of `max-width: 420px`.




<!-- Issuehunt content -->

---

<details>
<summary>
<b>IssueHunt Summary</b>
</summary>

### Referenced issues

This pull request has been submitted to:
- [#131: User Settings header adjustment](https://issuehunt.io/repos/208844948/issues/131)
---
</details>
<!-- /Issuehunt content-->