### PR TITLE
ux: Getting rid of the structured form "not in context"

### DIFF
--- a/src/components/new-preprint.js
+++ b/src/components/new-preprint.js
@@ -103,6 +103,7 @@ export default function NewPreprint({
           identifier={identifier}
           preprint={preprint}
           resolvePreprintStatus={resolvePreprintStatus}
+          onViewInContext={onViewInContext}
         />
       ) : preprint && step === 'NEW_REVIEW' ? (
         <StepReview
@@ -174,7 +175,8 @@ function StepPreprint({
   preprint,
   actions,
   fetchActionsProgress,
-  resolvePreprintStatus
+  resolvePreprintStatus,
+  onViewInContext
 }) {
   const history = useHistory();
   const location = useLocation();
@@ -297,7 +299,10 @@ function StepPreprint({
         </Button>
         <Button
           onClick={e => {
-            onStep('NEW_REVIEW');
+            onViewInContext({
+              preprint,
+              tab: 'review'
+            });
           }}
           disabled={
             fetchActionsProgress.isActive ||
@@ -321,7 +326,8 @@ StepPreprint.propTypes = {
   preprint: PropTypes.object,
   resolvePreprintStatus: PropTypes.object.isRequired,
   actions: PropTypes.array.isRequired,
-  fetchActionsProgress: PropTypes.object.isRequired
+  fetchActionsProgress: PropTypes.object.isRequired,
+  onViewInContext: PropTypes.func.isRequired
 };
 
 function StepReview({
@@ -474,14 +480,6 @@ function StepRequest({
           {isSingleStep ? 'Cancel' : 'Go Back'}
         </Button>
 
-        <Button
-          onClick={e => {
-            onViewInContext({ preprint, tab: 'request' });
-          }}
-          disabled={postData.isActive}
-        >
-          View In Context
-        </Button>
         <Button
           primary={true}
           isWaiting={postData.isActive}


### PR DESCRIPTION
Closes #134.

I would recommend to split up the file `new-preprint.js` into multiple files at some point.
It is hard to read and to not get lost in the file with 570 LOC and multiple components.


<!-- Issuehunt content -->

---

<details>
<summary>
<b>IssueHunt Summary</b>
</summary>

### Referenced issues

This pull request has been submitted to:
- [#134: Getting rid of the structured form "not in context"](https://issuehunt.io/repos/208844948/issues/134)
---
</details>
<!-- /Issuehunt content-->