### PR TITLE
fix: Searching for already added preprints by DOI doesn't yield any results

### DIFF
--- a/src/utils/search.js
+++ b/src/utils/search.js
@@ -97,11 +97,8 @@ export function apifyPreprintQs(uiQs = '', bookmark) {
 
   if (ui.has('q')) {
     const q = ui.get('q');
-    const splt = q.split(/(\s+)/);
 
-    const ored = [
-      `name:${splt.length > 1 && escapeLucene(q) === q ? JSON.stringify(q) : q}` // we auto quote multiple terms if they do not contain lucene operators
-    ];
+    const ored = [`name:"${escapeLucene(q)}"`];
 
     const doiMatched = q.match(doiRegex());
     if (doiMatched) {

--- a/test/test-search-utils.js
+++ b/test/test-search-utils.js
@@ -36,7 +36,7 @@ describe('search utils', () => {
       const p = querystring.parse(apifyPreprintQs(ui).substring(1));
       assert.equal(
         p.q,
-        'name:text AND hasReviews:true AND (subjectName:"influenza" OR subjectName:"zika")'
+        'name:"text" AND hasReviews:true AND (subjectName:"influenza" OR subjectName:"zika")'
       );
     });
 


### PR DESCRIPTION
Closes #114.

This was very hard to debug.

Before my changes, the search worked and delivered results for words ("hello world") or arXivId ("1909.13766") just fine.

When entering a DOI, the first part of the http request to the API would look like this: 
`http://127.0.0.1:3000/api/preprint/?q=(name:10.1101/780627+OR+doi:"10.1101/780627")`

The `doi:` part would have worked because it was encapsulated with quotes, but the `name:` part was not quoted for single words and crashed the api call with a 500 error because it could not interpret the value 10.1101/780627, since there is a forward slash in the middle of the value.

A user can input any kind of characters into the search bar, so the safest way was to always quote the `name:` part.

Alternatively, another solution would be to only query for: 
- doi when doi is matched
- arXivId when arXivId is matched
- name for when there is no match otherwise

But then, that would defeat the whole purpose of having OR queries.


<!-- Issuehunt content -->

---

<details>
<summary>
<b>IssueHunt Summary</b>
</summary>

### Referenced issues

This pull request has been submitted to:
- [#114: Searching for already added preprints by DOI doesn't yield any results](https://issuehunt.io/repos/208844948/issues/114)
---
</details>
<!-- /Issuehunt content-->