### PR TITLE
Improve search

### DIFF
--- a/src/utils/search.js
+++ b/src/utils/search.js
@@ -97,8 +97,15 @@ export function apifyPreprintQs(uiQs = '', bookmark) {
 
   if (ui.has('q')) {
     const q = ui.get('q');
+    const terms = q.split(/[+|\s]/).filter(Boolean);
 
     const ored = [`name:"${escapeLucene(q)}"`];
+
+    if (terms.length > 1) {
+      ored.push(`name:"${escapeLucene(q)}"~5`);
+    } else if (terms.length === 1) {
+      ored.push(`name:${escapeLucene(terms[0])}*`);
+    }
 
     const doiMatched = q.match(doiRegex());
     if (doiMatched) {


### PR DESCRIPTION
Fix #144 

If you search for a **single term**, it will use both normal (old) search and [Wildcard search](https://lucene.apache.org/core/4_3_0/queryparser/org/apache/lucene/queryparser/classic/package-summary.html#Wildcard_Searches). **Multiple terms** will use both normal and [Proximity search](https://lucene.apache.org/core/4_3_0/queryparser/org/apache/lucene/queryparser/classic/package-summary.html#Proximity_Searches) (with a distance of 5, which seems good)


Example queries:

**Old search:**
  - `covi`: 0 results
  - `covid`: 63 results
  - `corona`: 2 results
  - `coronavirus`: 38 results
  - `deep neural network`: 0 results

**New search:**
  - `covi`: 66 results
  - `covid`: 66 results
  - `corona`: 41 results
  - `coronavirus`: 39 results
  - `deep neural network`: 1 result  (_Classification of COVID-19 in chest X-ray images using DeTraC deep convolutional neural network_)

--- 

It's also possible to add [Fuzzy Search](https://lucene.apache.org/core/4_3_0/queryparser/org/apache/lucene/queryparser/classic/package-summary.html#Fuzzy_Searches), but I tried and it didn't seem to improve the results. 
For instance, if you search `COVID`, a title containing `provide` will score more (appear first) than one containing `COVID-19`. Another example is if you search for `corona`, a title containing `colony` will appear before one with `coronavirus`

I tried to use [Boosting](https://lucene.apache.org/core/4_3_0/queryparser/org/apache/lucene/queryparser/classic/package-summary.html#Boosting_a_Term), but it doesn't seem to work with [Term Modifiers](https://lucene.apache.org/core/4_3_0/queryparser/org/apache/lucene/queryparser/classic/package-summary.html#Term_Modifiers).
