### PR TITLE
Fix PDF fallback

### DIFF
--- a/src/components/extension-fallback.js
+++ b/src/components/extension-fallback.js
@@ -79,7 +79,7 @@ export default function ExtensionFallback() {
             {/* fallback text in case we can't load the PDF */}
             <Suspense fallback={<SuspenseLoading>Loading PDF</SuspenseLoading>}>
               <PdfViewer
-                docId={identifier}
+                docId={preprintId}
                 loading={<SuspenseLoading>Loading PDF</SuspenseLoading>}
               />
             </Suspense>


### PR DESCRIPTION
`preprintId` should be used in the `docId` attribute, just like here: https://github.com/prereview/rapid-prereview/blob/16e9bfe7ca522edab2bfb4f85b855d37b33313a5/src/components/extension-fallback.js#L67-L68

This was causing an error since the `preprintId` parameter was incorrect.

![a](https://user-images.githubusercontent.com/68347722/88716429-6f3c2900-d0f5-11ea-9e48-cd3e85b2a71d.png)
![b](https://user-images.githubusercontent.com/68347722/88716434-6fd4bf80-d0f5-11ea-9286-33208cfb412f.png)


I also noticed that the **fallback PDF** is always being fetched, even if it's not used. Not sure if this is a bug.
![c](https://user-images.githubusercontent.com/68347722/88718105-dd81eb00-d0f7-11ea-9fb7-84be52220428.png)

According to this line of code, it should be a fallback, right?
https://github.com/prereview/rapid-prereview/blob/16e9bfe7ca522edab2bfb4f85b855d37b33313a5/src/components/extension-fallback.js#L79