### PR TITLE
Allow multiple terms to be used on search

### DIFF
--- a/src/components/dashboard.js
+++ b/src/components/dashboard.js
@@ -49,16 +49,17 @@ export default function Dashboard() {
     location.state && location.state.bookmark
   );
 
+  const covidTerms = ['COVID-19', 'Coronavirus', 'SARS-CoV-2'];
   const params = new URLSearchParams(location.search);
 
   useEffect(() => {
     if (location.search === "") {
-      history.replace({ search: "q=COVID-19" })
+      history.replace({ search: createPreprintQs({ text: covidTerms }, location.search) });
     }
   }, [apiQs]);
 
   const [preprints, fetchResultsProgress] = usePreprintSearchResults(apiQs);
-  
+
   const [hoveredSortOption, setHoveredSortOption] = useState(null);
 
   /**
@@ -189,7 +190,7 @@ export default function Dashboard() {
                       onChange={e => {
                         const search = createPreprintQs(
                           {
-                            text: 'COVID-19',
+                            text: covidTerms,
                             hasOthersRec: e.target.checked || null
                           },
                           location.search
@@ -216,7 +217,7 @@ export default function Dashboard() {
                       onChange={e => {
                         const search = createPreprintQs(
                           {
-                            text: 'COVID-19',
+                            text: covidTerms,
                             hasPeerRec: e.target.checked || null
                           },
                           location.search
@@ -243,7 +244,7 @@ export default function Dashboard() {
                       onChange={e => {
                         const search = createPreprintQs(
                           {
-                            text: 'COVID-19',
+                            text: covidTerms,
                             hasData: e.target.checked || null
                           },
                           location.search
@@ -270,7 +271,7 @@ export default function Dashboard() {
                       onChange={e => {
                         const search = createPreprintQs(
                           {
-                            text: 'COVID-19',
+                            text: covidTerms,
                             hasCode: e.target.checked || null
                           },
                           location.search
@@ -298,7 +299,7 @@ export default function Dashboard() {
                   ) => {
                     const search = createPreprintQs(
                       {
-                        text: 'COVID-19' || 'coronavirus' || 'SARS-CoV2',
+                        text: covidTerms,
                         sort: nextSortOption
                       },
                       location.search
@@ -346,7 +347,7 @@ export default function Dashboard() {
                       onClick={() => {
                         history.push({
                           pathname: location.pathname,
-                          search: createPreprintQs({ text: params.get('q') }, location.search)
+                          search: createPreprintQs({ text: params.getAll('q') }, location.search)
                         });
                       }}
                     >
@@ -363,7 +364,7 @@ export default function Dashboard() {
                         onClick={() => {
                           history.push({
                             pathname: location.pathname,
-                            search: createPreprintQs({ text: params.get('q') }, location.search),
+                            search: createPreprintQs({ text: params.getAll('q') }, location.search),
                             state: { bookmark: preprints.bookmark }
                           });
                         }}

--- a/test/test-search-utils.js
+++ b/test/test-search-utils.js
@@ -40,6 +40,15 @@ describe('search utils', () => {
       );
     });
 
+    it('should allow multiple terms to be used', () => {
+      const ui = createPreprintQs({ text: ['text1', 'text2'] });
+
+      assert.equal(ui, '?q=text1&q=text2');
+
+      const p = querystring.parse(apifyPreprintQs(ui).substring(1));
+      assert.equal(p.q, '(name:"text1" OR name:text1* OR name:"text2" OR name:text2*)' );
+    });
+
     it('should handle DOI and arXivId', () => {
       const ui = createPreprintQs({
         text: `text ${arXivId} ${crossrefDoi} ${openAireDoi}`


### PR DESCRIPTION
Fix #157 

This allows multiple terms to be used to search something. It's currently used in the dashboard to search for `covid-19`, `coronavirus` and `sars-cov-2`. This will search for `covid-19` or `coronavirus` or `sars-cov-2`.

![a](https://user-images.githubusercontent.com/68347722/89236816-f5f67780-d5c7-11ea-80e1-add9e89167de.png)

*NOTE*: I had to comment this previously uncommented code: https://github.com/PREreview/rapid-prereview/pull/156/files#diff-fa1057ed4f5107fbe5f137ce299389e7 to be able to test this because it was causing an error (something like `dim "hasPeerRec" does not exist`). I'm not sure if this only happens on my environment.

<!-- Issuehunt content -->

---

<details>
<summary>
<b>IssueHunt Summary</b>
</summary>

### Referenced issues

This pull request has been submitted to:
- [#157: Craft a query to lookup multiple search terms in preprint titles](https://issuehunt.io/repos/208844948/issues/157)
---
</details>
<!-- /Issuehunt content-->