### PR TITLE
PdfViewer: Fix PDF fallback when preprint is not in the database

### DIFF
--- a/src/components/extension-fallback.js
+++ b/src/components/extension-fallback.js
@@ -66,6 +66,7 @@ export default function ExtensionFallback() {
           <Suspense fallback={<SuspenseLoading>Loading PDF</SuspenseLoading>}>
             <PdfViewer
               docId={preprintId}
+              pdfUrl={pdfUrl}
               loading={<SuspenseLoading>Loading PDF</SuspenseLoading>}
             />
           </Suspense>
@@ -80,6 +81,7 @@ export default function ExtensionFallback() {
             <Suspense fallback={<SuspenseLoading>Loading PDF</SuspenseLoading>}>
               <PdfViewer
                 docId={identifier}
+                pdfUrl={pdfUrl}
                 loading={<SuspenseLoading>Loading PDF</SuspenseLoading>}
               />
             </Suspense>

--- a/src/components/pdf-viewer.js
+++ b/src/components/pdf-viewer.js
@@ -11,7 +11,7 @@ const CSS_MAX_WIDTH = 900; // keep in sync with CSS
  * This implement an infinite scroll mechanism so that we never load more than a
  * few pages at the time
  */
-export default function PdfViewer({ docId, loading }) {
+export default function PdfViewer({ docId, pdfUrl, loading }) {
   const containerEl = useRef(null);
   const getWidth = () => {
     const el = containerEl.current;
@@ -79,7 +79,7 @@ export default function PdfViewer({ docId, loading }) {
         <Document
           file={`${process.env.API_URL}/api/pdf?preprintId=${encodeURIComponent(
             docId
-          )}`}
+          )}${pdfUrl ? `&pdfUrl=${encodeURIComponent(pdfUrl)}` : ''}`}
           loading={loading}
           onLoadSuccess={async pdf => {
             let dims = [];


### PR DESCRIPTION
Fixes #167!

PdfViewer can't display PDFs for preprints that are not in the database, even though we have the `pdfUrl` that we got from `/api/resolve`.

This fixes it by passing the `pdfUrl` (that we got from `/api/resolve`) to `/api/pdf` so it can be used when available.

Old behavior (Failed to load PDF):
![old](https://user-images.githubusercontent.com/68347722/89367866-7e504780-d6b0-11ea-86b7-0a023cc12bf3.png)

New behavior:
![fixed](https://user-images.githubusercontent.com/68347722/89367876-84debf00-d6b0-11ea-89da-ff67e17717d8.png)
