### PR TITLE
Fix query being reset when selecting a filter

### DIFF
--- a/src/components/dashboard.js
+++ b/src/components/dashboard.js
@@ -53,7 +53,7 @@ export default function Dashboard() {
   const params = new URLSearchParams(location.search);
 
   useEffect(() => {
-    if (location.search === "") {
+    if (!params.get('q')) {
       history.replace({ search: createPreprintQs({ text: covidTerms }, location.search) });
     }
   }, [apiQs]);
@@ -190,7 +190,7 @@ export default function Dashboard() {
                       onChange={e => {
                         const search = createPreprintQs(
                           {
-                            text: covidTerms,
+                            text: params.getAll('q'),
                             hasOthersRec: e.target.checked || null
                           },
                           location.search
@@ -217,7 +217,7 @@ export default function Dashboard() {
                       onChange={e => {
                         const search = createPreprintQs(
                           {
-                            text: covidTerms,
+                            text: params.getAll('q'),
                             hasPeerRec: e.target.checked || null
                           },
                           location.search
@@ -244,7 +244,7 @@ export default function Dashboard() {
                       onChange={e => {
                         const search = createPreprintQs(
                           {
-                            text: covidTerms,
+                            text: params.getAll('q'),
                             hasData: e.target.checked || null
                           },
                           location.search
@@ -271,7 +271,7 @@ export default function Dashboard() {
                       onChange={e => {
                         const search = createPreprintQs(
                           {
-                            text: covidTerms,
+                            text: params.getAll('q'),
                             hasCode: e.target.checked || null
                           },
                           location.search
@@ -299,7 +299,7 @@ export default function Dashboard() {
                   ) => {
                     const search = createPreprintQs(
                       {
-                        text: covidTerms,
+                        text: params.getAll('q'),
                         sort: nextSortOption
                       },
                       location.search


### PR DESCRIPTION
Also fix issue where default query would not be applied when using filters (because location.search would not be empty).

See https://github.com/PREreview/rapid-prereview/commit/ddfb5610c3b3b322d0c3530f51abe4fd8e6bea86#commitcomment-41279137