### PR TITLE
Add extension banner to the hompage

### DIFF
--- a/src/components/header-bar.css
+++ b/src/components/header-bar.css
@@ -43,6 +43,12 @@
     border-top-left-radius: var(--xsgrd);
     border-bottom-left-radius: var(--xsgrd);
     box-shadow: 0px 2px 4px rgba(0, 0, 0, 0.2);
+    @media (--narrow-screen) {
+      bottom: calc(var(--xlgrd) + 50px);
+    }
+    @media (--mobile) {
+      bottom: var(--xlgrd);
+    }
     & :any-link {
       color: white;
       text-decoration: none;

--- a/src/components/home.css
+++ b/src/components/home.css
@@ -140,10 +140,6 @@
     }
     & :any-link {
       color: white;
-      text-decoration: none;
-      &:hover {
-        text-decoration: underline;
-      }
     }
   }
 }

--- a/src/components/home.css
+++ b/src/components/home.css
@@ -38,7 +38,7 @@
     flex: 0 0 var(--middle-column-default-width);
     width: var(--middle-column-default-width);
     max-width: calc(100vw - var(--left-panel-min-width));
-
+    margin-bottom: 60px;
     position: relative;
     box-sizing: border-box;
     @media (--narrow-screen) {
@@ -101,6 +101,49 @@
     justify-content: center;
     & .button {
       margin: var(--xsgrd);
+    }
+  }
+
+  & .home__extention-banner {
+    position: fixed;
+    text-align: center;
+    font: var(--ui-basic-font);
+    font-size: medium;
+    line-height: 1.25em;
+    background-color: var(--prereview-red);
+    color: white;
+    flex: 0 0 var(--middle-column-default-width);
+    text-shadow: 0px 0px 10px #eb0000;
+    left: var(--left-panel-min-width);
+    bottom: 0;
+    width: var(--middle-column-default-width);
+    max-width: calc(80vw - var(--left-panel-min-width));
+    padding: var(--xsgrd) var(--xlgrd);
+    margin: var(--mgrd) var(--sgrd) 0;
+    border-top-left-radius: var(--xsgrd);
+    border-top-right-radius: var(--xsgrd);
+    box-shadow: 0px 2px 4px rgba(0, 0, 0, 0.2);
+    z-index: 1000;
+    @media (--narrow-screen) {
+      left: 0;
+      font-size: inherit;
+      max-width: calc(100vw - 130px);
+    }
+    @media (--mobile) {
+      display: none;
+    }
+    & .home-extension-banner__close-button {
+      position: absolute;
+      right: 0;
+      top: 0;
+      color: inherit;
+    }
+    & :any-link {
+      color: white;
+      text-decoration: none;
+      &:hover {
+        text-decoration: underline;
+      }
     }
   }
 }

--- a/src/components/home.js
+++ b/src/components/home.js
@@ -42,7 +42,7 @@ export default function Home() {
   const [showLeftPanel, setShowLeftPanel] = useState(!isMobile);
   const [loginModalOpenNext, setLoginModalOpenNext] = useState(null);
   const isNewVisitor = useIsNewVisitor();
-  const [displayExtensionBanner, closeExtensionBanner] = useDisplayExtensionBanner();
+  const [displayExtensionBanner, closeExtensionBanner, checkForExtension] = useDisplayExtensionBanner();
   const [isWelcomeModalOpen, setIsWelcomeModalOpen] = useState(true);
   const [newPreprints, setNewPreprints] = useNewPreprints();
 
@@ -120,6 +120,7 @@ export default function Home() {
         <WelcomeModal
           onClose={() => {
             setIsWelcomeModalOpen(false);
+            checkForExtension();
           }}
         />
       )}

--- a/src/components/home.js
+++ b/src/components/home.js
@@ -8,7 +8,8 @@ import { usePreprintSearchResults } from '../hooks/api-hooks';
 import {
   useIsNewVisitor,
   useIsMobile,
-  useNewPreprints
+  useNewPreprints,
+  useDisplayExtensionBanner
 } from '../hooks/ui-hooks';
 import { useUser } from '../contexts/user-context';
 import { unprefix, getId } from '../utils/jsonld';
@@ -26,6 +27,9 @@ import { createPreprintQs, apifyPreprintQs } from '../utils/search';
 import WelcomeModal from './welcome-modal';
 import XLink from './xlink';
 import AddButton from './add-button';
+import IconButton from './icon-button';
+import VisuallyHidden from '@reach/visually-hidden';
+import { MdClose } from 'react-icons/md';
 import { ORG } from '../constants';
 import Banner from './banner';
 
@@ -38,6 +42,7 @@ export default function Home() {
   const [showLeftPanel, setShowLeftPanel] = useState(!isMobile);
   const [loginModalOpenNext, setLoginModalOpenNext] = useState(null);
   const isNewVisitor = useIsNewVisitor();
+  const [displayExtensionBanner, closeExtensionBanner] = useDisplayExtensionBanner();
   const [isWelcomeModalOpen, setIsWelcomeModalOpen] = useState(true);
   const [newPreprints, setNewPreprints] = useNewPreprints();
 
@@ -323,6 +328,25 @@ export default function Home() {
         </div>
 
         <div className="home__main__right"></div>
+        {
+          displayExtensionBanner && (<div className="home__extention-banner">
+            You have not yet installed the Outbreak Science Rapid PREreivew browser extension to enable requesting, adding and/or reading rapid reviews on other websites. Install it&nbsp;
+            <a
+              href="https://outbreaksci.prereview.org/extension"
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              here
+            </a>!
+            <IconButton
+              className="home-extension-banner__close-button"
+              onClick={closeExtensionBanner}
+            >
+              <VisuallyHidden>Close</VisuallyHidden>
+              <MdClose className="home-extension-banner_close-button__icon" />
+            </IconButton>
+          </div>)
+        }
       </div>
     </div>
   );

--- a/src/hooks/ui-hooks.js
+++ b/src/hooks/ui-hooks.js
@@ -163,12 +163,16 @@ export function usePrevious(value) {
 export function useDisplayExtensionBanner() {
   const [displayExtensionBanner, setDisplayExtensionBanner] = useState(false);
   
+  const checkForExtension = () => {
+    setTimeout(() => {
+      const shouldDisplayExtensionBanner = localStorage.getItem('displayExtensionBanner') !== 'false' && !document.getElementById(CSS_SCOPE_ID);
+      setDisplayExtensionBanner(shouldDisplayExtensionBanner);
+    },500);
+  }
+  
   useEffect(() => {
     if(document.readyState === 'interactive' || document.readyState === 'complete'){
-      setTimeout(() => {
-        const shouldDisplayExtensionBanner = localStorage.getItem('displayExtensionBanner') !== 'false' && !document.getElementById(CSS_SCOPE_ID);
-        setDisplayExtensionBanner(shouldDisplayExtensionBanner);
-      },500)
+      checkForExtension();
     }
   }, []);
 
@@ -177,5 +181,5 @@ export function useDisplayExtensionBanner() {
     setDisplayExtensionBanner(false);
   }, []);
 
-  return [displayExtensionBanner, localSet];
+  return [displayExtensionBanner, localSet, checkForExtension];
 }

--- a/src/hooks/ui-hooks.js
+++ b/src/hooks/ui-hooks.js
@@ -1,4 +1,7 @@
 import { useState, useEffect, useCallback, useRef } from 'react';
+import {
+  CSS_SCOPE_ID
+} from '../constants';
 import { useStores } from '../contexts/store-context';
 
 /**
@@ -155,4 +158,24 @@ export function usePrevious(value) {
 
   // Return previous value (happens before update in useEffect above)
   return ref.current;
+}
+
+export function useDisplayExtensionBanner() {
+  const [displayExtensionBanner, setDisplayExtensionBanner] = useState(false);
+  
+  useEffect(() => {
+    if(document.readyState === 'interactive' || document.readyState === 'complete'){
+      setTimeout(() => {
+        const shouldDisplayExtensionBanner = localStorage.getItem('displayExtensionBanner') !== 'false' && !document.getElementById(CSS_SCOPE_ID);
+        setDisplayExtensionBanner(shouldDisplayExtensionBanner);
+      },500)
+    }
+  }, []);
+
+  const localSet = useCallback(() => {
+    localStorage.setItem('displayExtensionBanner', 'false');
+    setDisplayExtensionBanner(false);
+  }, []);
+
+  return [displayExtensionBanner, localSet];
 }


### PR DESCRIPTION
Fixes #164 

Note: 

- Banner is displayed only on Home Page
- On click of close button - banner will be hided even after reload (stored in localstorage)
- No change in extension code
- Hided by default on mobile screen
- Desktop Screenshot
  ![image](https://user-images.githubusercontent.com/15967809/90222508-b74c9280-ddfb-11ea-8518-f64130372719.png)

- Medium size screens -> FeedBack banner is moved a little up
  ![image](https://user-images.githubusercontent.com/15967809/90223034-ce3fb480-ddfc-11ea-80f4-fbd01bc8dee0.png)

- On Mobile banner is hidden and FeedBack banner moved back to previous position
  ![image](https://user-images.githubusercontent.com/15967809/90222911-89b41900-ddfc-11ea-8b44-02615712f6fe.png)


<!-- Issuehunt content -->

---

<details>
<summary>
<b>IssueHunt Summary</b>
</summary>

### Referenced issues

This pull request has been submitted to:
- [#164: Add extension banner to the hompage](https://issuehunt.io/repos/208844948/issues/164)
---
</details>
<!-- /Issuehunt content-->